### PR TITLE
Default instance for functors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,10 @@ An `Invariant` instance should satisfy the following laws:
 - Composition: `invmap g1 g2 <<< invmap f1 f2 = invmap (g1 <<< f1) (f2 <<< g2)`
 
 
-#### `invmapF`
+#### `invariantFromFunctor`
 
 ``` purescript
-invmapF :: forall f a b. (Functor f) => (a -> b) -> (b -> a) -> f a -> f b
+instance invariantFromFunctor :: (Functor f) => Invariant f
 ```
 
-As all `Functor`s are also trivially `Invariant`, this function can be
-used as the `invmap` implementation for all `Invariant` instances for
-`Functors`.
-
-#### `invariantArr`
-
-``` purescript
-instance invariantArr :: Invariant (Prim.Function a)
-```
+All `Functor`s are also trivially `Invariant`.

--- a/src/Data/Functor/Invariant.purs
+++ b/src/Data/Functor/Invariant.purs
@@ -12,11 +12,6 @@ module Data.Functor.Invariant where
 class Invariant f where
   invmap :: forall a b. (a -> b) -> (b -> a) -> f a -> f b
 
--- | As all `Functor`s are also trivially `Invariant`, this function can be
--- | used as the `invmap` implementation for all `Invariant` instances for
--- | `Functors`.
-invmapF :: forall f a b. (Functor f) => (a -> b) -> (b -> a) -> f a -> f b
-invmapF = const <<< (<$>)
-
-instance invariantArr :: Invariant ((->) a) where
-  invmap = invmapF
+-- | All `Functor`s are also trivially `Invariant`.
+instance invariantFromFunctor :: (Functor f) => Invariant f where
+  invmap = const <<< (<$>)


### PR DESCRIPTION
@paf31 is this OK? I didn't even try it at first, expecting overlap problems, but @joneshf suggested it, I tried it, and it seems to be fine.

My test case for seeing whether instances would resolve was using `Endo` in `Data.Monoid`:

``` purescript
module Test where

import Data.String
import Data.Functor.Invariant
import Data.Monoid.Endo

test = runEndo (invmap show length (Endo \x -> x :: Number)) "fooooooooooo"
-- "12"
```

And likewise `invmap` works for things with `Functor` instances and no `Invariant`.
