### PR TITLE
Prepare for 2.0 release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^1.0.0"
+    "purescript-prelude": "^2.1.0"
   }
 }

--- a/src/Data/Functor/Invariant.purs
+++ b/src/Data/Functor/Invariant.purs
@@ -1,6 +1,5 @@
 module Data.Functor.Invariant where
 
-import Data.Function (const, (<<<))
 import Data.Functor (class Functor, map)
 
 -- | A type of functor that can be used to adapt the type of a wrapped function
@@ -25,4 +24,4 @@ instance invariantArray :: Invariant Array where
 -- | used as the `imap` implementation for any types that has an existing
 -- | `Functor` instance.
 imapF :: forall f a b. Functor f => (a -> b) -> (b -> a) -> f a -> f b
-imapF = const <<< map
+imapF f _ = map f


### PR DESCRIPTION
@paf31 I know we talked about this before, but is there a reason not to provide an instance like this, rather than making every type with a `Functor` instance implement its own using `imapF`?

I thought one of the advantages of disallowing orphans is it made instances like this perfectly acceptable. Also, it's not like there's a case here where there's a more efficient implementation for `imap` for existing `Functors` - unlike using `rmap` for the `Functor` instance for `Bifunctor`s, etc.
